### PR TITLE
Fix account provider certificate clean up 

### DIFF
--- a/pkg/plugin/provider/dynamicDir.go
+++ b/pkg/plugin/provider/dynamicDir.go
@@ -1,6 +1,8 @@
 package pkg
 
 import (
+	"github.com/sirupsen/logrus"
+
 	"fmt"
 	"os"
 )
@@ -41,6 +43,7 @@ func CreateDynamicDirectory(namespace string) error {
 
 func RemoveDynamicDirectory(namespace string) error {
 	subDirectory := fmt.Sprintf("%s/%s", gmsaDirectory, namespace)
+	logrus.Infof("Removing directory %s", subDirectory)
 	if _, err := os.Stat(subDirectory); !os.IsNotExist(err) {
 		err = os.RemoveAll(subDirectory)
 		if err != nil {

--- a/pkg/plugin/provider/server.go
+++ b/pkg/plugin/provider/server.go
@@ -20,7 +20,7 @@ type HTTPServer struct {
 
 func (h *HTTPServer) StartServer(errChan chan error, namespace string, disableMTLS bool) (string, error) {
 	// use a host allocated port
-	ln, err := net.Listen("tcp", ":0")
+	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		return "", fmt.Errorf("failed to create http listener for http server: %v", err)
 	}


### PR DESCRIPTION
This PR fixes issues found with how the account provider cleans up its certificates upon a helm uninstall.

I found that, when errors are encountered during the cleanup, the helm hooks can be a bit racey and will immediately remove the pod without allowing the user to inspect any of the error messages. After more testing I found that this issue does not actually impact the clean up operation when no errors are encountered.

This PR also changes the account provider server such that it will only listen on localhost, as designed. This change was included in a security branch I have been working on, but it's simple enough (and important enough) to be included in this PR which will be merged before I raise the security PR. 