### PR TITLE
fix release dockerhub password secret

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: build-all-binaries
         run: bash ./scripts/build
       - name: package-binaries


### PR DESCRIPTION
Goland replace-all didn't seem to touch the tag-release workflow, but somehow did properly update all other workflows. This fixes that. 