### PR TITLE
Ensure CCG Reference is cleaned up upon uninstall of the CCG Plugin

### DIFF
--- a/pkg/plugin/manager/uninstall-plugin.ps1
+++ b/pkg/plugin/manager/uninstall-plugin.ps1
@@ -97,6 +97,9 @@ $key.SetAccessControl($acl)
 # deregister with regsvcs
 & "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\regsvcs" /u "C:\Program Files\RancherGMSACredentialProvider\RanchergMSACredentialProvider.dll"
 
+# Remove CCG reference
+Get-ChildItem Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\CCG\COMClasses | Where {$_.Name -match "{e4781092-f116-4b79-b55e-28eb6a224e26}"} | Remove-Item
+
 #Set owner back to original owner and remove access rule for current user. 
 $acl = $key.GetAccessControl()
 $acl.RemoveAccessRule($rule)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/43358

During installation a registry key is added to `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\CCG\COMClasses` which advertises the CCGRKC dll to CCG so it can be invoked. Previously we were not cleaning up that key when the plugin was uninstalled. This PR adds in the logic to properly remove that subkey upon uninstallation 

## Testing

I've manually tested this change by creating a windows cluster with the CCG feature installed and properly configured. I uploaded the updated script to the Windows Worker and exec'd into the account-provider pod (since it runs as the `SYSTEM` user). After running the command I confirmed that the subkey was properly deleted and that no errors were reported by the script. 