### PR TITLE
Use lowercase vault URLs

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -61,8 +61,8 @@ jobs:
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
+            secret/data/github/repo/rancher-plugin-gmsa/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/rancher-plugin-gmsa/dockerhub/rancher/credentials password | DOCKER_PASSWORD
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:

--- a/.github/workflows/tag-prerelease.yaml
+++ b/.github/workflows/tag-prerelease.yaml
@@ -71,8 +71,8 @@ jobs:
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
+            secret/data/github/repo/rancher-plugin-gmsa/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/rancher-plugin-gmsa/dockerhub/rancher/credentials password | DOCKER_PASSWORD
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -65,8 +65,8 @@ jobs:
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
+            secret/data/github/repo/rancher-plugin-gmsa/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/rancher-plugin-gmsa/dockerhub/rancher/credentials password | DOCKER_PASSWORD
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:


### PR DESCRIPTION
This repository is one of the few which uses capitalized characters in its name. The rancher vault expects all repositories to use lowercase letters when accessing secrets, so simply using `${{ github.repository }}` did not properly retrieve the secrets. This PR hard codes the repository name and removes any use of capital characters 