### PR TITLE
Remove dapper

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-./.dapper
 ./.cache
 ./.github

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -3,7 +3,7 @@ name: Pull Request CI
 on:
   pull_request:
     paths-ignore:
-      - '*.dapper'
+      - '*.build'
       - '.gitignore'
       - 'CODEOWNERS'
       - 'LICENSE'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.dapper
 /.cache
 /bin
 /dist
@@ -11,7 +10,6 @@
 .vscode/
 .DS_Store
 .charts-build-scripts
-/Dockerfile.dapper*
 /coverage
 
 # globs

--- a/Dockerfile-windows.build
+++ b/Dockerfile-windows.build
@@ -1,8 +1,8 @@
 FROM rancher/golang:1.16-windowsservercore
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG DAPPER_HOST_ARCH
-ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+ARG ARCH
+ENV HOST_ARCH=${ARCH} ARCH=${ARCH}
 
 RUN pushd c:\; \
     $URL = 'https://github.com/StefanScherer/docker-cli-builder/releases/download/20.10.21/docker.exe'; \
@@ -31,11 +31,7 @@ RUN pushd c:\; \
     Write-Host 'Complete.'; \
     popd;
 
-ENV DAPPER_ENV REPO TAG DRONE_TAG
-ENV DAPPER_SOURCE /source
-ENV DAPPER_DOCKER_SOCKET true
-ENV HOME ${DAPPER_SOURCE}
+WORKDIR /source
 
-WORKDIR ${DAPPER_SOURCE}
 ENTRYPOINT ["powershell", "-NoLogo", "-NonInteractive", "-File", "./scripts/windows/entry.ps1"]
 CMD ["ci"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,7 @@
-FROM registry.suse.com/bci/golang:1.19-20.21
+FROM registry.suse.com/bci/golang:1.25.9
 
-ARG DAPPER_HOST_ARCH
-ENV ARCH $DAPPER_HOST_ARCH
+ARG ARCH
+ENV ARCH=${ARCH}
 
 RUN zypper -n install git docker vim less file curl wget patch
 RUN if [ "${ARCH}" == "amd64" ]; then \
@@ -15,13 +15,7 @@ ARG yamllint_version=1.26.3
 LABEL yamllint_version=$yamllint_version
 RUN pip install "yamllint==$yamllint_version"
 
-ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS
-ENV DAPPER_SOURCE /go/src/github.com/rancher/Rancher-Plugin-gMSA/
-ENV DAPPER_OUTPUT ./bin ./dist
-ENV DAPPER_DOCKER_SOCKET true
-ENV GOPATH /go
-ENV HOME ${DAPPER_SOURCE}
-WORKDIR ${DAPPER_SOURCE}
+WORKDIR /source
 
 ENTRYPOINT ["./scripts/entry"]
 CMD ["ci"]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,32 @@
 TARGETS := $(shell ls scripts)
+BUILD_IMAGE := gmsa-builder
+CURDIR := $(shell pwd)
+host_uid := $(shell id -u 2>/dev/null || echo 1000)
+host_gid := $(shell id -g 2>/dev/null || echo 1000)
 
-.dapper:
-	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/latest/dapper-$$(uname -s)-$$(uname -m) > .dapper.tmp
-	@@chmod +x .dapper.tmp
-	@./.dapper.tmp -v
-	@mv .dapper.tmp .dapper
+# Detect OS: on Windows, OS=Windows_NT is set by the environment
+ifeq ($(OS),Windows_NT)
+  DOCKERFILE := Dockerfile-windows.build
+  DOCKER_SOCKET_MOUNT := -v //./pipe/docker_engine://./pipe/docker_engine
+else
+  DOCKERFILE := Dockerfile.build
+  DOCKER_SOCKET_MOUNT := -v /var/run/docker.sock:/var/run/docker.sock
+endif
 
-$(TARGETS): .dapper
-	./.dapper $@
+RAW_HOST_ARCH := $(shell uname -m 2>/dev/null || echo amd64)
+HOST_ARCH := $(if $(filter x86_64,$(RAW_HOST_ARCH)),amd64,$(if $(filter aarch64,$(RAW_HOST_ARCH)),arm64,$(RAW_HOST_ARCH)))
+
+build-image:
+	docker build -f $(DOCKERFILE) -t $(BUILD_IMAGE) --build-arg ARCH=$(HOST_ARCH) .
+
+$(TARGETS): build-image
+	docker run --rm \
+		$(DOCKER_SOCKET_MOUNT) \
+		-v $(CURDIR):/source \
+		-e REPO -e TAG -e DRONE_TAG -e CROSS \
+		-e "HOST_UID=${host_uid}" \
+		-e "HOST_GID=${host_gid}" \
+		$(BUILD_IMAGE) $@
 
 .DEFAULT_GOAL := default
 

--- a/scripts/entry
+++ b/scripts/entry
@@ -2,10 +2,23 @@
 set -e
 
 mkdir -p bin dist
+
+restore_permissions() {
+    if [ -z "${HOST_UID:-}" ] || [ -z "${HOST_GID:-}" ]; then
+        return
+    fi
+
+    if [ "${HOST_UID}" = "0" ]; then
+        return
+    fi
+
+    chown -R "${HOST_UID}:${HOST_GID}" /source 2>/dev/null || true
+}
+
+trap restore_permissions EXIT INT TERM
+
 if [ -e ./scripts/$1 ]; then
     ./scripts/"$@"
 else
     exec "$@"
 fi
-
-chown -R $DAPPER_UID:$DAPPER_GID .


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/54315 
 
Before this PR, CI had already been migrated to GitHub Actions and no longer depended on Dapper. Dapper was primarily used for local image builds, which are infrequent in practice.

This PR removes Dapper and related files from the repository. It is not meant to fix any existing problem with building the image locally.


The make command has been tested in a Linux environment to verify that it continues to work as expected.